### PR TITLE
Make the image smaller, remove some unused files or packages

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -77,7 +77,11 @@ RUN zypper --non-interactive install --no-recommends \
   yast2-ycp-ui-bindings \
   && zypper clean --all \
   && rm -rf /usr/lib*/ruby/gems/*/cache/ \
-  && rm -rf /usr/share/doc/
+  && rm -rf /usr/share/doc/ \
+  && rpm -e --nodeps kbd kbd-legacy \
+  && find /usr/lib/locale/* -maxdepth 1 | grep -v -E "(en_US|cs_CZ|es_ES|de_DE|C.utf8)" | xargs rm -rf \
+  && find /usr/share/locale -name "*.mo" -delete
+
 
 COPY yast-travis-ruby /usr/local/bin/
 RUN chmod a+x /usr/local/bin/yast-travis-ruby


### PR DESCRIPTION
- Removed unused locales (everything besides some possibly used by the YaST developers in the tests)
- Removed unused translations (MO files)
- Removed unnecessary packages (kbd, kbd-legacy - setting the keyboard or the console font does not make sense in a docker container anyway)

The size of the image decreased from ~835MB to ~600MB (saving ~235MB, 28%), quite a lot.