### PR TITLE
Ensure all Rubygems are installed for Ruby 2.7

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -26,22 +26,22 @@ RUN zypper --non-interactive install --no-recommends \
   which \
   libxml2-tools \
   libxslt-tools \
-  "rubygem(abstract_method)" \
-  "rubygem(cfa)" \
-  "rubygem(cheetah)" \
-  "rubygem(coveralls)" \
-  "rubygem(gettext)" \
-  "rubygem(parallel)" \
-  "rubygem(parallel_tests)" \
-  "rubygem(raspell)" \
-  "rubygem(rspec)" \
-  "rubygem(ruby:2.6.0:rubocop:0.41.2)" \
-  "rubygem(ruby:2.6.0:rubocop:0.71.0)" \
-  "rubygem(simplecov)" \
-  "rubygem(simpleidn)" \
-  "rubygem(suse-connect)" \
-  "rubygem(yard)" \
-  "rubygem(yast-rake)" \
+  "rubygem(ruby:2.7.0:abstract_method)" \
+  "rubygem(ruby:2.7.0:cfa)" \
+  "rubygem(ruby:2.7.0:cheetah)" \
+  "rubygem(ruby:2.7.0:coveralls)" \
+  "rubygem(ruby:2.7.0:gettext)" \
+  "rubygem(ruby:2.7.0:parallel)" \
+  "rubygem(ruby:2.7.0:parallel_tests)" \
+  "rubygem(ruby:2.7.0:raspell)" \
+  "rubygem(ruby:2.7.0:rspec)" \
+  "rubygem(ruby:2.7.0:rubocop:0.41.2)" \
+  "rubygem(ruby:2.7.0:rubocop:0.71.0)" \
+  "rubygem(ruby:2.7.0:simplecov)" \
+  "rubygem(ruby:2.7.0:simpleidn)" \
+  "rubygem(ruby:2.7.0:suse-connect)" \
+  "rubygem(ruby:2.7.0:yard)" \
+  "rubygem(ruby:2.7.0:yast-rake)" \
   build \
   obs-service-source_validator \
   openSUSE-release-ftp \


### PR DESCRIPTION
- Avoid mixing Ruby 2.6 and Ruby 2.7 gems
- Unfortunately for Docker images built in OBS we cannot use [this trick](https://github.com/yast/docker-yast-ruby/blob/master/Dockerfile.latest#L35-L49) :worried: 