### PR TITLE
Drop yast2-inetd

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -55,7 +55,6 @@ RUN zypper --non-interactive install --no-recommends \
   yast2-country \
   yast2-devtools \
   yast2-hardware-detection \
-  yast2-inetd \
   yast2-installation \
   yast2-installation-control \
   yast2-ldap \


### PR DESCRIPTION
the package was dropped 2 years ago but if it survives here it will break
building yast2-schema with
/usr/src/app/src/rng/profile.rng:11:76: error: reference to undefined pattern "FLAG__X_SuSE_YaST_AutoInstResource__not_set__in_inetd"

https://github.com/yast/yast-inetd
https://travis-ci.org/github/yast/yast-schema/builds/694550703 from https://github.com/yast/yast-schema/pull/77