### PR TITLE
Removed "brp-extract-appdata", dropped in Factory

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -18,7 +18,6 @@ RUN zypper addrepo --refresh http://download.opensuse.org/repositories/YaST:/Hea
 
 RUN zypper --non-interactive install --no-recommends \
   brp-check-suse \
-  brp-extract-appdata \
   aspell-en \
   fdupes \
   git \


### PR DESCRIPTION
## Problem

- The image does not build in OBS because of `unresolvable: nothing provides brp-extract-appdata` error
- See https://build.opensuse.org/package/show/YaST:Head/ci-ruby-container
- The package has been dropped from Factory/Tumbleweed ([delete request](https://build.opensuse.org/request/show/959999))

## Solution

- Remove the package from the list
