### PR TITLE
Change the owner to pass a new git security check

### DIFF
--- a/package/yast-ci-ruby
+++ b/package/yast-ci-ruby
@@ -288,6 +288,16 @@ fi
 # the rest is a package build if it is disabled then just finish now
 [ "$RUN_BUILD_PACKAGE" == "0" ] && exit 0
 
+# ensure the files are owned by the current (root) user,
+# git would fail if the owner is different like when running in GitHub Actions
+# ("git clone" is called in a VM as a non-root user, but when running an action
+# in a Docker container it runs as root which is the Docker default)
+# https://github.blog/2022-04-18-highlights-from-git-2-36/
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/
+if [ "$UID" == "0" ]; then
+  chown -c 0 .
+fi
+
 # run package with all its checks, but be silent as possible. STDOUT is sent to dev null due to output of tar command
 rake --silent package > /dev/null
 


### PR DESCRIPTION
## Problem

- Running `git` in GitHub Actions failed with the latest Git in Tumbleweed
- Example: https://github.com/yast/yast-iscsi-client/runs/6076837887?check_suite_focus=true

## Solution

- It turned out to be caused by a new Git security check
- https://github.blog/2022-04-18-highlights-from-git-2-36/
- https://github.blog/2022-04-12-git-security-vulnerability-announced/
- It works fine with this patch, see https://github.com/yast/yast-iscsi-client/runs/6081755910?check_suite_focus=true

## Notes

Originally I wanted to fix it in the Docker image by running `git config --global --add safe.directory "*"` ([link](https://build.opensuse.org/package/rdiff/YaST:Head/ci-ruby-container?linkrev=base&rev=37)), but that didn't work. The reason is that GitHub Actions override `$HOME` and point it to its own directory so everything in the original `$HOME` in the Docker image is ignored.