### PR TITLE
Install glibc-locale

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -22,6 +22,7 @@ RUN zypper --non-interactive install --no-recommends \
   fdupes \
   git \
   grep \
+  glibc-locale \
   rpm-build \
   update-desktop-files \
   which \


### PR DESCRIPTION
## Problem

The `glibc-locale` YaST dependency was replaced with much smaller `glibc-locale-base` which covers only the basic locales (`C` and `en_US`). It is related to this change: https://github.com/libyui/libyui/pull/77

But some unit tests deliberately use additional locales to check some locale specific behavior and they now fail.

## Solution

Install the `glibc-locale` package explicitly.

## Notes

Tested with this commit: https://github.com/yast/yast-core/commit/897492c98b44f79a1c681c5075d808421ebb4687, I'll remove it after merging this fix.
