### PR TITLE
Change the ownership recursively in GitHub Actions

### DIFF
--- a/package/yast-ci-ruby
+++ b/package/yast-ci-ruby
@@ -295,7 +295,7 @@ fi
 # https://github.blog/2022-04-18-highlights-from-git-2-36/
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/
 if [ "$UID" == "0" ]; then
-  chown -c 0 .
+  chown -R -c 0 .
 fi
 
 # run package with all its checks, but be silent as possible. STDOUT is sent to dev null due to output of tar command


### PR DESCRIPTION
## Problem

- Fixes the `detected dubious ownership in repository` error in GitHub Actions
- Example failure: https://github.com/yast/yast-kdump/runs/7534826120?check_suite_focus=true#step:4:6
- It seems that the git check is more strict now...

## Solution

- Change the ownership recursively for the complete Git checkout

## Testing

- Tested with this commit https://github.com/yast/yast-kdump/commit/74e1f04b76455e5464b31225a9e56be7bdb7f032
- Works fine: https://github.com/yast/yast-kdump/runs/7535171065?check_suite_focus=true#step:5:5

