### PR TITLE
Upgrade to Ruby 3.4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -34,7 +34,6 @@ RUN zypper --non-interactive install --no-recommends \
   "rubygem(ruby:3.4.0:gettext)" \
   "rubygem(ruby:3.4.0:parallel)" \
   "rubygem(ruby:3.4.0:parallel_tests)" \
-  "rubygem(ruby:3.4.0:raspell)" \
   "rubygem(ruby:3.4.0:rspec)" \
   "rubygem(ruby:3.4.0:rubocop:0.41.2)" \
   "rubygem(ruby:3.4.0:rubocop:0.71.0)" \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -34,6 +34,7 @@ RUN zypper --non-interactive install --no-recommends \
   "rubygem(ruby:3.4.0:gettext)" \
   "rubygem(ruby:3.4.0:parallel)" \
   "rubygem(ruby:3.4.0:parallel_tests)" \
+  "rubygem(ruby:3.4.0:raspell)" \
   "rubygem(ruby:3.4.0:rspec)" \
   "rubygem(ruby:3.4.0:rubocop:0.41.2)" \
   "rubygem(ruby:3.4.0:rubocop:0.71.0)" \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -28,22 +28,22 @@ RUN zypper --non-interactive install --no-recommends \
   which \
   libxml2-tools \
   libxslt-tools \
-  "rubygem(ruby:3.3.0:abstract_method)" \
-  "rubygem(ruby:3.3.0:cfa)" \
-  "rubygem(ruby:3.3.0:cheetah)" \
-  "rubygem(ruby:3.3.0:gettext)" \
-  "rubygem(ruby:3.3.0:parallel)" \
-  "rubygem(ruby:3.3.0:parallel_tests)" \
-  "rubygem(ruby:3.3.0:raspell)" \
-  "rubygem(ruby:3.3.0:rspec)" \
-  "rubygem(ruby:3.3.0:rubocop:0.41.2)" \
-  "rubygem(ruby:3.3.0:rubocop:0.71.0)" \
-  "rubygem(ruby:3.3.0:rubocop:1.24.1)" \
-  "rubygem(ruby:3.3.0:simplecov)" \
-  "rubygem(ruby:3.3.0:simplecov-lcov)" \
-  "rubygem(ruby:3.3.0:simpleidn)" \
-  "rubygem(ruby:3.3.0:yard)" \
-  "rubygem(ruby:3.3.0:yast-rake)" \
+  "rubygem(ruby:3.4.0:abstract_method)" \
+  "rubygem(ruby:3.4.0:cfa)" \
+  "rubygem(ruby:3.4.0:cheetah)" \
+  "rubygem(ruby:3.4.0:gettext)" \
+  "rubygem(ruby:3.4.0:parallel)" \
+  "rubygem(ruby:3.4.0:parallel_tests)" \
+  "rubygem(ruby:3.4.0:raspell)" \
+  "rubygem(ruby:3.4.0:rspec)" \
+  "rubygem(ruby:3.4.0:rubocop:0.41.2)" \
+  "rubygem(ruby:3.4.0:rubocop:0.71.0)" \
+  "rubygem(ruby:3.4.0:rubocop:1.24.1)" \
+  "rubygem(ruby:3.4.0:simplecov)" \
+  "rubygem(ruby:3.4.0:simplecov-lcov)" \
+  "rubygem(ruby:3.4.0:simpleidn)" \
+  "rubygem(ruby:3.4.0:yard)" \
+  "rubygem(ruby:3.4.0:yast-rake)" \
   build \
   obs-service-source_validator \
   openSUSE-release-ftp \


### PR DESCRIPTION
## Problem

- The container does not build anymore and the last successful build contains the previous Ruby 3.3 packages which cause problems with the new Ruby 3.4

## Solution

- Upgrade the dependencies to Ruby 3.4
- Drop the `raspell` gem, it does not compile with Ruby 3.4 and is used only in the yast.github.io repository for spellchecking

## Notes

- I'll remove the spellchecker call from the  yast.github.io repository
