### PR TITLE
Drop old Rubocop versions

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -36,8 +36,6 @@ RUN zypper --non-interactive install --no-recommends \
   "rubygem(ruby:3.4.0:parallel_tests)" \
   "rubygem(ruby:3.4.0:raspell)" \
   "rubygem(ruby:3.4.0:rspec)" \
-  "rubygem(ruby:3.4.0:rubocop:0.41.2)" \
-  "rubygem(ruby:3.4.0:rubocop:0.71.0)" \
   "rubygem(ruby:3.4.0:rubocop:1.24.1)" \
   "rubygem(ruby:3.4.0:simplecov)" \
   "rubygem(ruby:3.4.0:simplecov-lcov)" \


### PR DESCRIPTION
## Problem

- The image does not build, "unresolvable: nothing provides rubygem(ruby:3.4.0:jaro_winkler:1.5) >= 1.5.1 needed by ruby3.4-rubygem-rubocop-0_71"
- That gem does not build with Ruby 3.4

## Solution

- Drop the old Rubocop versions, they are not used anymore in the maintained YaST packages
- The old version is used only in two packages, we should just update the version when touching the packages:
  - widget-demo: https://github.com/yast/yast-widget-demo/blob/master/.rubocop.yml#L3
  - autoyast2-schemas: https://github.com/yast/autoyast2-schemas/blob/master/.rubocop.yml#L3
- The packages have been also dropped from OBS

## Testing

- Tested manually, the image builds locally

